### PR TITLE
Add wheel prerequisite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 all:
+	pip install wheel
 	python setup.py sdist bdist_wheel
 install:
 	pip install -e .


### PR DESCRIPTION
The action on merged commits failed to publish because `wheel` should be pre-installed.