### PR TITLE
Move synthimpute dependency to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ all:
 	pip install wheel
 	python setup.py sdist bdist_wheel
 install:
-	pip install -e .
 	pip install git+https://github.com/PSLmodels/openfisca-uk
+	pip install git+https://github.com/PSLmodels/synthimpute
+	pip install -e .
 format:
 	black . -l 79
 test:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(
         "tqdm",
         "tables",
         "h5py",
-        "synthimpute @ git+https://github.com/PSLmodels/synthimpute",
     ],
     entry_points={
         "console_scripts": ["openfisca-uk-data=openfisca_uk_data.cli:main"],


### PR DESCRIPTION
Moves the synthimpute dependency to the Makefile from setup.py, which should enable the PyPI package publication.